### PR TITLE
Add support for movable, non-copyable iterators.

### DIFF
--- a/include/boost/foreach.hpp
+++ b/include/boost/foreach.hpp
@@ -73,6 +73,7 @@
 #include <boost/mpl/logical.hpp>
 #include <boost/mpl/eval_if.hpp>
 #include <boost/noncopyable.hpp>
+#include <boost/move/move.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/rend.hpp>
@@ -257,6 +258,10 @@ struct auto_any : auto_any_base
 {
     explicit auto_any(T const &t)
       : item(t)
+    {
+    }
+    explicit auto_any(BOOST_RV_REF(T) t)
+      : item(boost::move(t))
     {
     }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -32,5 +32,6 @@ test-suite "foreach"
       [ run rvalue_nonconst_r.cpp ]
       [ run dependent_type.cpp ]
       [ run misc.cpp ]
+      [ compile iter_movable.cpp ]
       [ compile noncopyable.cpp ]
     ;

--- a/test/iter_movable.cpp
+++ b/test/iter_movable.cpp
@@ -1,0 +1,71 @@
+//  (C) Copyright Janusz Lewandowski 2013.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/*
+Revision history:
+18 December 2013 : Initial version.
+*/
+
+#include <boost/test/minimal.hpp>
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+///////////////////////////////////////////////////////////////////////////////
+// define a type with movable iterator and teach BOOST_FOREACH how to enumerate it
+//
+namespace mine
+{
+    struct dummy
+    {
+        struct iterator : public std::iterator<std::output_iterator_tag, int>
+        {
+            iterator() = default;
+            iterator(const iterator&) = delete;
+            iterator(iterator&&) = default;
+            iterator& operator++() {return *this;}
+            int& operator*() {return *(new int());}
+        };
+    };
+
+    bool operator==(const dummy::iterator&, const dummy::iterator&) { return false; }
+    bool operator!=(const dummy::iterator&, const dummy::iterator&) { return true; }
+
+    dummy::iterator range_begin(dummy&) {return {};}
+    dummy::iterator range_end(dummy&) {return {};}
+    dummy::iterator range_begin(const dummy&) {return {};}
+    dummy::iterator range_end(const dummy&) {return {};}
+}
+
+#include <boost/foreach.hpp>
+
+namespace boost
+{
+    template<>
+    struct range_mutable_iterator<mine::dummy>
+    {
+        typedef mine::dummy::iterator type;
+    };
+    template<>
+    struct range_const_iterator<mine::dummy>
+    {
+        typedef mine::dummy::iterator type;
+    };
+}
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// test_main
+//
+int test_main( int, char*[] )
+{
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    // loop over the dummy type (just make sure this compiles)
+    mine::dummy t;
+    BOOST_FOREACH(int c , t)
+    {
+        ((void)c); // no-op
+    }
+#endif
+    return 0;
+}


### PR DESCRIPTION
This way it's possible to use BOOST_FOREACH with move-only iterators.
