### PR TITLE
Foreach uses makes undocumented assumptions about type traits types

### DIFF
--- a/include/boost/foreach.hpp
+++ b/include/boost/foreach.hpp
@@ -398,10 +398,16 @@ struct foreach_reference
 // encode_type
 //
 template<typename T>
-inline type2type<T> *encode_type(T &, boost::mpl::false_ *) { return 0; }
+inline type2type<T> *encode_type(T &, boost::false_type*) { return 0; }
 
 template<typename T>
-inline type2type<T, const_> *encode_type(T const &, boost::mpl::true_ *) { return 0; }
+inline type2type<T, const_> *encode_type(T const &, boost::true_type*) { return 0; }
+
+template<typename T>
+inline type2type<T> *encode_type(T &, boost::mpl::false_*) { return 0; }
+
+template<typename T>
+inline type2type<T, const_> *encode_type(T const &, boost::mpl::true_*) { return 0; }
 
 ///////////////////////////////////////////////////////////////////////////////
 // set_false


### PR DESCRIPTION
Exposed by ongoing type traits rewrite / simplification: there is no documented inheritance from an mpl type to a type traits type.  This is probably the simplest fix for the problem.