### PR TITLE
Replace 0 by nullptr

### DIFF
--- a/include/boost/foreach.hpp
+++ b/include/boost/foreach.hpp
@@ -30,6 +30,13 @@
 #include <boost/config.hpp>
 #include <boost/detail/workaround.hpp>
 
+// Define a compiler generic null pointer value
+#if !defined(BOOST_NO_NULLPTR)
+#define BOOST_FOREACH_NULL 0
+#else
+#define BOOST_FOREACH_NULL nullptr
+#endif
+
 // Some compilers let us detect even const-qualified rvalues at compile-time
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)                                                   \
  || defined(BOOST_MSVC) && !defined(_PREFAST_)                                 \
@@ -909,7 +916,7 @@ rderef(auto_any_t cur, type2type<T, C> *)
 
 // A sneaky way to get the type of the collection without evaluating the expression
 #define BOOST_FOREACH_TYPEOF(COL)                                                               \
-    (true ? nullptr : boost::foreach_detail_::encode_type(COL, boost::foreach_detail_::is_const_(COL)))
+    (true ? BOOST_FOREACH_NULL : boost::foreach_detail_::encode_type(COL, boost::foreach_detail_::is_const_(COL)))
 
 // returns true_* if the type is noncopyable
 #define BOOST_FOREACH_IS_NONCOPYABLE(COL)                                                       \
@@ -939,7 +946,7 @@ rderef(auto_any_t cur, type2type<T, C> *)
     (COL)
 
 # define BOOST_FOREACH_SHOULD_COPY(COL)                                                         \
-    (true ? nullptr : boost::foreach_detail_::or_(                                                    \
+    (true ? BOOST_FOREACH_NULL : boost::foreach_detail_::or_(                                                    \
         BOOST_FOREACH_IS_RVALUE(COL)                                                            \
       , BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL)))
 
@@ -962,11 +969,11 @@ rderef(auto_any_t cur, type2type<T, C> *)
 // If the type happens to be a lightweight proxy, always make a copy.
 # define BOOST_FOREACH_SHOULD_COPY(COL)                                                         \
     (boost::foreach_detail_::should_copy_impl(                                                  \
-        true ? nullptr : boost::foreach_detail_::or_(                                                 \
+        true ? BOOST_FOREACH_NULL : boost::foreach_detail_::or_(                                                 \
             boost::foreach_detail_::is_array_(COL)                                              \
           , BOOST_FOREACH_IS_NONCOPYABLE(COL)                                                   \
           , boost::foreach_detail_::not_(boost::foreach_detail_::is_const_(COL)))               \
-      , true ? nullptr : BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL)                                      \
+      , true ? BOOST_FOREACH_NULL : BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL)                                      \
       , &BOOST_FOREACH_ID(_foreach_is_rvalue)))
 
 #elif !defined(BOOST_FOREACH_NO_RVALUE_DETECTION)
@@ -985,7 +992,7 @@ rderef(auto_any_t cur, type2type<T, C> *)
 // Determine whether the collection expression is an lvalue or an rvalue.
 // NOTE: this gets the answer wrong for const rvalues.
 # define BOOST_FOREACH_SHOULD_COPY(COL)                                                         \
-    (true ? nullptr : boost::foreach_detail_::or_(                                                    \
+    (true ? BOOST_FOREACH_NULL : boost::foreach_detail_::or_(                                                    \
         boost::foreach_detail_::is_rvalue_((COL), 0)                                            \
       , BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL)))
 
@@ -1004,7 +1011,7 @@ rderef(auto_any_t cur, type2type<T, C> *)
 
 // Can't use rvalues with BOOST_FOREACH (unless they are lightweight proxies)
 # define BOOST_FOREACH_SHOULD_COPY(COL)                                                         \
-    (true ? nullptr : BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL))
+    (true ? BOOST_FOREACH_NULL : BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL))
 
 #endif
 

--- a/include/boost/foreach.hpp
+++ b/include/boost/foreach.hpp
@@ -939,7 +939,7 @@ rderef(auto_any_t cur, type2type<T, C> *)
     (COL)
 
 # define BOOST_FOREACH_SHOULD_COPY(COL)                                                         \
-    (true ? 0 : boost::foreach_detail_::or_(                                                    \
+    (true ? nullptr : boost::foreach_detail_::or_(                                                    \
         BOOST_FOREACH_IS_RVALUE(COL)                                                            \
       , BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL)))
 
@@ -962,11 +962,11 @@ rderef(auto_any_t cur, type2type<T, C> *)
 // If the type happens to be a lightweight proxy, always make a copy.
 # define BOOST_FOREACH_SHOULD_COPY(COL)                                                         \
     (boost::foreach_detail_::should_copy_impl(                                                  \
-        true ? 0 : boost::foreach_detail_::or_(                                                 \
+        true ? nullptr : boost::foreach_detail_::or_(                                                 \
             boost::foreach_detail_::is_array_(COL)                                              \
           , BOOST_FOREACH_IS_NONCOPYABLE(COL)                                                   \
           , boost::foreach_detail_::not_(boost::foreach_detail_::is_const_(COL)))               \
-      , true ? 0 : BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL)                                      \
+      , true ? nullptr : BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL)                                      \
       , &BOOST_FOREACH_ID(_foreach_is_rvalue)))
 
 #elif !defined(BOOST_FOREACH_NO_RVALUE_DETECTION)
@@ -985,7 +985,7 @@ rderef(auto_any_t cur, type2type<T, C> *)
 // Determine whether the collection expression is an lvalue or an rvalue.
 // NOTE: this gets the answer wrong for const rvalues.
 # define BOOST_FOREACH_SHOULD_COPY(COL)                                                         \
-    (true ? 0 : boost::foreach_detail_::or_(                                                    \
+    (true ? nullptr : boost::foreach_detail_::or_(                                                    \
         boost::foreach_detail_::is_rvalue_((COL), 0)                                            \
       , BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL)))
 
@@ -1004,7 +1004,7 @@ rderef(auto_any_t cur, type2type<T, C> *)
 
 // Can't use rvalues with BOOST_FOREACH (unless they are lightweight proxies)
 # define BOOST_FOREACH_SHOULD_COPY(COL)                                                         \
-    (true ? 0 : BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL))
+    (true ? nullptr : BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(COL))
 
 #endif
 

--- a/include/boost/foreach.hpp
+++ b/include/boost/foreach.hpp
@@ -31,7 +31,7 @@
 #include <boost/detail/workaround.hpp>
 
 // Define a compiler generic null pointer value
-#if !defined(BOOST_NO_NULLPTR)
+#if defined(BOOST_NO_NULLPTR)
 #define BOOST_FOREACH_NULL 0
 #else
 #define BOOST_FOREACH_NULL nullptr

--- a/include/boost/foreach.hpp
+++ b/include/boost/foreach.hpp
@@ -909,7 +909,7 @@ rderef(auto_any_t cur, type2type<T, C> *)
 
 // A sneaky way to get the type of the collection without evaluating the expression
 #define BOOST_FOREACH_TYPEOF(COL)                                                               \
-    (true ? 0 : boost::foreach_detail_::encode_type(COL, boost::foreach_detail_::is_const_(COL)))
+    (true ? nullptr : boost::foreach_detail_::encode_type(COL, boost::foreach_detail_::is_const_(COL)))
 
 // returns true_* if the type is noncopyable
 #define BOOST_FOREACH_IS_NONCOPYABLE(COL)                                                       \


### PR DESCRIPTION
Since I use [clazy](https://github.com/KDE/clazy) I have such warnings:

```
warning: zero as null pointer constant
    foreach.hpp: 1100:77: note expanded from macro BOOST_FOREACH
    foreach.hpp: 1014:9: note expanded from macro BOOST_FOREACH_CONTAIN
    foreach.hpp: 942:13: note expanded from macro BOOST_FOREACH_SHOULD_COPY
````

This PR aims to fix this.