### PR TITLE
Remove broken web link.

### DIFF
--- a/doc/foreach.qbk
+++ b/doc/foreach.qbk
@@ -510,7 +510,7 @@ code which demonstrated that a pure library solution might be possible. The code
 proposed C++\/CLI dialect of the time, for which there was no compiler as of yet. I was intrigued by
 the possibility, and I ported his code to Managed C++ and got it working. We worked together to
 refine the idea and eventually published an article about it in the November 2003 issue of the
-[@http://www.cuj.com CUJ].
+CUJ.
 
 After leaving Microsoft, I revisited the idea of a looping construct. I reimplemented the macro
 from scratch in standard C++, corrected some shortcomings of the CUJ version and rechristened it


### PR DESCRIPTION
The CUJ website is no more, and the link points to a payday loan company is is not what we want here!