### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/foreach.hpp
+++ b/include/boost/foreach.hpp
@@ -49,7 +49,7 @@
 // Some compilers allow temporaries to be bound to non-const references.
 // These compilers make it impossible to for BOOST_FOREACH to detect
 // temporaries and avoid reevaluation of the collection expression.
-# if BOOST_WORKAROUND(__BORLANDC__, < 0x593)                                                    \
+# if BOOST_WORKAROUND(BOOST_BORLANDC, < 0x593)                                                    \
   || (BOOST_WORKAROUND(BOOST_INTEL_CXX_VERSION, <= 700) && defined(_MSC_VER))                   \
   || BOOST_WORKAROUND(__SUNPRO_CC, < 0x5100)                                                    \
   || BOOST_WORKAROUND(__DECCXX_VER, <= 60590042)
@@ -65,7 +65,7 @@
   || BOOST_WORKAROUND(__IBMCPP__, BOOST_TESTED_AT(600))                                         \
   || BOOST_WORKAROUND(__MWERKS__, BOOST_TESTED_AT(0x3206))                                      \
   || BOOST_WORKAROUND(__SUNPRO_CC, >= 0x5100)                                                   \
-  || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x590))
+  || BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x590))
 #  define BOOST_FOREACH_NO_CONST_RVALUE_DETECTION
 # else
 #  define BOOST_FOREACH_RUN_TIME_CONST_RVALUE_DETECTION
@@ -436,7 +436,7 @@ inline T *&to_ptr(T const &)
 }
 
 // Borland needs a little extra help with arrays
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 template<typename T,std::size_t N>
 inline T (*&to_ptr(T (&)[N]))[N]
 {


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.