### PR TITLE
Switch from deprecated test to Lightweight Test

### DIFF
--- a/test/array_byref.cpp
+++ b/test/array_byref.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,19 +30,19 @@ int const (&my_const_array)[5] = my_array;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // non-const containers by reference
-    BOOST_CHECK(sequence_equal_byref_n(my_array, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byref_n(my_array, "\1\2\3\4\5"));
 
     // const containers by reference
-    BOOST_CHECK(sequence_equal_byref_c(my_const_array, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byref_c(my_const_array, "\1\2\3\4\5"));
 
     // mutate the mutable collections
     mutate_foreach_byref(my_array);
 
     // compare the mutated collections to the actual results
-    BOOST_CHECK(sequence_equal_byref_n(my_array, "\2\3\4\5\6"));
+    BOOST_TEST(sequence_equal_byref_n(my_array, "\2\3\4\5\6"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/array_byref_r.cpp
+++ b/test/array_byref_r.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,19 +30,19 @@ int const (&my_const_array)[5] = my_array;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // non-const containers by reference
-    BOOST_CHECK(sequence_equal_byref_n_r(my_array, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byref_n_r(my_array, "\5\4\3\2\1"));
 
     // const containers by reference
-    BOOST_CHECK(sequence_equal_byref_c_r(my_const_array, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byref_c_r(my_const_array, "\5\4\3\2\1"));
 
     // mutate the mutable collections
     mutate_foreach_byref_r(my_array);
 
     // compare the mutated collections to the actual results
-    BOOST_CHECK(sequence_equal_byref_n_r(my_array, "\6\5\4\3\2"));
+    BOOST_TEST(sequence_equal_byref_n_r(my_array, "\6\5\4\3\2"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/array_byval.cpp
+++ b/test/array_byval.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,15 +30,15 @@ int const (&my_const_array)[5] = my_array;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     boost::mpl::false_ *p = BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(my_array);
     (void)p;
     // non-const containers by value
-    BOOST_CHECK(sequence_equal_byval_n(my_array, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byval_n(my_array, "\1\2\3\4\5"));
 
     // const containers by value
-    BOOST_CHECK(sequence_equal_byval_c(my_const_array, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byval_c(my_const_array, "\1\2\3\4\5"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/array_byval_r.cpp
+++ b/test/array_byval_r.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,16 +30,16 @@ int const (&my_const_array)[5] = my_array;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     boost::mpl::false_ *p = BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(my_array);
     (void)p;
 
     // non-const containers by value
-    BOOST_CHECK(sequence_equal_byval_n_r(my_array, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byval_n_r(my_array, "\5\4\3\2\1"));
 
     // const containers by value
-    BOOST_CHECK(sequence_equal_byval_c_r(my_const_array, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byval_c_r(my_const_array, "\5\4\3\2\1"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/call_once.cpp
+++ b/test/call_once.cpp
@@ -9,7 +9,7 @@
 */
 
 #include <vector>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 // counter
@@ -27,14 +27,14 @@ std::vector<int> const &get_vector()
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     BOOST_FOREACH(int i, get_vector())
     {
         ((void)i); // no-op
     }
 
-    BOOST_CHECK(1 == counter);
+    BOOST_TEST(1 == counter);
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/cstr_byref.cpp
+++ b/test/cstr_byref.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -31,19 +31,19 @@ char const *my_const_ntcs  = my_ntcs;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // non-const containers by reference
-    BOOST_CHECK(sequence_equal_byref_n(my_ntcs, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byref_n(my_ntcs, "\1\2\3\4\5"));
 
     // const containers by reference
-    BOOST_CHECK(sequence_equal_byref_c(my_const_ntcs, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byref_c(my_const_ntcs, "\1\2\3\4\5"));
 
     // mutate the mutable collections
     mutate_foreach_byref(my_ntcs);
 
     // compare the mutated collections to the actual results
-    BOOST_CHECK(sequence_equal_byref_n(my_ntcs, "\2\3\4\5\6"));
+    BOOST_TEST(sequence_equal_byref_n(my_ntcs, "\2\3\4\5\6"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/cstr_byref_r.cpp
+++ b/test/cstr_byref_r.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -31,19 +31,19 @@ char const *my_const_ntcs  = my_ntcs;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // non-const containers by reference
-    BOOST_CHECK(sequence_equal_byref_n_r(my_ntcs, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byref_n_r(my_ntcs, "\5\4\3\2\1"));
 
     // const containers by reference
-    BOOST_CHECK(sequence_equal_byref_c_r(my_const_ntcs, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byref_c_r(my_const_ntcs, "\5\4\3\2\1"));
 
     // mutate the mutable collections
     mutate_foreach_byref_r(my_ntcs);
 
     // compare the mutated collections to the actual results
-    BOOST_CHECK(sequence_equal_byref_n_r(my_ntcs, "\6\5\4\3\2"));
+    BOOST_TEST(sequence_equal_byref_n_r(my_ntcs, "\6\5\4\3\2"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/cstr_byval.cpp
+++ b/test/cstr_byval.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -31,16 +31,16 @@ char const *my_const_ntcs  = my_ntcs;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     boost::mpl::true_ *p = BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(my_ntcs);
     (void)p;
 
     // non-const containers by value
-    BOOST_CHECK(sequence_equal_byval_n(my_ntcs, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byval_n(my_ntcs, "\1\2\3\4\5"));
 
     // const containers by value
-    BOOST_CHECK(sequence_equal_byval_c(my_const_ntcs, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byval_c(my_const_ntcs, "\1\2\3\4\5"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/cstr_byval_r.cpp
+++ b/test/cstr_byval_r.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -31,16 +31,16 @@ char const *my_const_ntcs  = my_ntcs;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     boost::mpl::true_ *p = BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(my_ntcs);
     (void)p;
 
     // non-const containers by value
-    BOOST_CHECK(sequence_equal_byval_n_r(my_ntcs, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byval_n_r(my_ntcs, "\5\4\3\2\1"));
 
     // const containers by value
-    BOOST_CHECK(sequence_equal_byval_c_r(my_const_ntcs, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byval_c_r(my_const_ntcs, "\5\4\3\2\1"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/dependent_type.cpp
+++ b/test/dependent_type.cpp
@@ -9,7 +9,7 @@
 */
 
 #include <vector>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -28,10 +28,10 @@ void do_test(Vector const & vect)
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     std::vector<int> vect;
     do_test(vect);
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/misc.cpp
+++ b/test/misc.cpp
@@ -11,7 +11,7 @@
 */
 
 #include <vector>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 struct xxx : std::vector<int>
@@ -41,7 +41,7 @@ struct yyy : std::vector<int>
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
-    return 0;
+    return boost::report_errors();
 }

--- a/test/pair_byref.cpp
+++ b/test/pair_byref.cpp
@@ -9,7 +9,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -32,19 +32,19 @@ std::pair<int const*,int const*> const my_const_pair(my_array,my_array+5);
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // non-const containers by reference
-    BOOST_CHECK(sequence_equal_byref_n(my_pair, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byref_n(my_pair, "\1\2\3\4\5"));
 
     // const containers by reference
-    BOOST_CHECK(sequence_equal_byref_c(my_const_pair, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byref_c(my_const_pair, "\1\2\3\4\5"));
 
     // mutate the mutable collections
     mutate_foreach_byref(my_pair);
 
     // compare the mutated collections to the actual results
-    BOOST_CHECK(sequence_equal_byref_n(my_pair, "\2\3\4\5\6"));
+    BOOST_TEST(sequence_equal_byref_n(my_pair, "\2\3\4\5\6"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/pair_byref_r.cpp
+++ b/test/pair_byref_r.cpp
@@ -9,7 +9,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -32,19 +32,19 @@ std::pair<int const*,int const*> const my_const_pair(my_array,my_array+5);
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // non-const containers by reference
-    BOOST_CHECK(sequence_equal_byref_n_r(my_pair, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byref_n_r(my_pair, "\5\4\3\2\1"));
 
     // const containers by reference
-    BOOST_CHECK(sequence_equal_byref_c_r(my_const_pair, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byref_c_r(my_const_pair, "\5\4\3\2\1"));
 
     // mutate the mutable collections
     mutate_foreach_byref_r(my_pair);
 
     // compare the mutated collections to the actual results
-    BOOST_CHECK(sequence_equal_byref_n_r(my_pair, "\6\5\4\3\2"));
+    BOOST_TEST(sequence_equal_byref_n_r(my_pair, "\6\5\4\3\2"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/pair_byval.cpp
+++ b/test/pair_byval.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -31,16 +31,16 @@ std::pair<int const*,int const*> const my_const_pair(my_array,my_array+5);
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     boost::mpl::true_ *p = BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(my_pair);
     (void)p;
 
     // non-const containers by value
-    BOOST_CHECK(sequence_equal_byval_n(my_pair, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byval_n(my_pair, "\1\2\3\4\5"));
 
     // const containers by value
-    BOOST_CHECK(sequence_equal_byval_c(my_const_pair, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byval_c(my_const_pair, "\1\2\3\4\5"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/pair_byval_r.cpp
+++ b/test/pair_byval_r.cpp
@@ -8,7 +8,7 @@
    25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -31,16 +31,16 @@ std::pair<int const*,int const*> const my_const_pair(my_array,my_array+5);
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     boost::mpl::true_ *p = BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(my_pair);
     (void)p;
 
     // non-const containers by value
-    BOOST_CHECK(sequence_equal_byval_n_r(my_pair, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byval_n_r(my_pair, "\5\4\3\2\1"));
 
     // const containers by value
-    BOOST_CHECK(sequence_equal_byval_c_r(my_const_pair, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byval_c_r(my_const_pair, "\5\4\3\2\1"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/rvalue_const.cpp
+++ b/test/rvalue_const.cpp
@@ -9,7 +9,7 @@
 */
 
 #include <vector>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 #ifdef BOOST_FOREACH_NO_CONST_RVALUE_DETECTION
@@ -27,7 +27,7 @@ std::vector<int> const get_vector()
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     int counter = 0;
 
@@ -36,9 +36,9 @@ int test_main( int, char*[] )
         counter += i;
     }
 
-    BOOST_CHECK(16 == counter);
+    BOOST_TEST(16 == counter);
 
-    return 0;
+    return boost::report_errors();
 }
 
 #endif

--- a/test/rvalue_const_r.cpp
+++ b/test/rvalue_const_r.cpp
@@ -9,7 +9,7 @@
 */
 
 #include <vector>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 #ifdef BOOST_FOREACH_NO_CONST_RVALUE_DETECTION
@@ -27,7 +27,7 @@ std::vector<int> const get_vector()
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     int counter = 0;
 
@@ -36,9 +36,9 @@ int test_main( int, char*[] )
         counter += i;
     }
 
-    BOOST_CHECK(16 == counter);
+    BOOST_TEST(16 == counter);
 
-    return 0;
+    return boost::report_errors();
 }
 
 #endif

--- a/test/rvalue_nonconst.cpp
+++ b/test/rvalue_nonconst.cpp
@@ -9,7 +9,7 @@
 */
 
 #include <vector>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 #ifdef BOOST_FOREACH_NO_RVALUE_DETECTION
@@ -24,7 +24,7 @@ std::vector<int> get_vector()
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     int counter = 0;
 
@@ -33,9 +33,9 @@ int test_main( int, char*[] )
         counter += i;
     }
 
-    BOOST_CHECK(16 == counter);
+    BOOST_TEST(16 == counter);
 
-    return 0;
+    return boost::report_errors();
 }
 
 #endif

--- a/test/rvalue_nonconst_r.cpp
+++ b/test/rvalue_nonconst_r.cpp
@@ -9,7 +9,7 @@
 */
 
 #include <vector>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 #ifdef BOOST_FOREACH_NO_RVALUE_DETECTION
@@ -24,7 +24,7 @@ std::vector<int> get_vector()
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     int counter = 0;
 
@@ -33,9 +33,9 @@ int test_main( int, char*[] )
         counter += i;
     }
 
-    BOOST_CHECK(16 == counter);
+    BOOST_TEST(16 == counter);
 
-    return 0;
+    return boost::report_errors();
 }
 
 #endif

--- a/test/stl_byref.cpp
+++ b/test/stl_byref.cpp
@@ -9,7 +9,7 @@
 */
 
 #include <list>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,19 +44,19 @@ std::list<int> const &my_const_list = my_list;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // non-const containers by reference
-    BOOST_CHECK(sequence_equal_byref_n(my_list, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byref_n(my_list, "\1\2\3\4\5"));
 
     // const containers by reference
-    BOOST_CHECK(sequence_equal_byref_c(my_const_list, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byref_c(my_const_list, "\1\2\3\4\5"));
 
     // mutate the mutable collections
     mutate_foreach_byref(my_list);
 
     // compare the mutated collections to the actual results
-    BOOST_CHECK(sequence_equal_byref_n(my_list, "\2\3\4\5\6"));
+    BOOST_TEST(sequence_equal_byref_n(my_list, "\2\3\4\5\6"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/stl_byref_r.cpp
+++ b/test/stl_byref_r.cpp
@@ -9,7 +9,7 @@
 */
 
 #include <list>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,19 +44,19 @@ std::list<int> const &my_const_list = my_list;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // non-const containers by reference
-    BOOST_CHECK(sequence_equal_byref_n_r(my_list, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byref_n_r(my_list, "\5\4\3\2\1"));
 
     // const containers by reference
-    BOOST_CHECK(sequence_equal_byref_c_r(my_const_list, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byref_c_r(my_const_list, "\5\4\3\2\1"));
 
     // mutate the mutable collections
     mutate_foreach_byref_r(my_list);
 
     // compare the mutated collections to the actual results
-    BOOST_CHECK(sequence_equal_byref_n_r(my_list, "\6\5\4\3\2"));
+    BOOST_TEST(sequence_equal_byref_n_r(my_list, "\6\5\4\3\2"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/stl_byval.cpp
+++ b/test/stl_byval.cpp
@@ -11,7 +11,7 @@
 */
 
 #include <list>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -46,16 +46,16 @@ std::list<int> const &my_const_list = my_list;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     boost::mpl::false_ *p = BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(my_list);
     (void)p;
 
     // non-const containers by value
-    BOOST_CHECK(sequence_equal_byval_n(my_list, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byval_n(my_list, "\1\2\3\4\5"));
 
     // const containers by value
-    BOOST_CHECK(sequence_equal_byval_c(my_const_list, "\1\2\3\4\5"));
+    BOOST_TEST(sequence_equal_byval_c(my_const_list, "\1\2\3\4\5"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/stl_byval_r.cpp
+++ b/test/stl_byval_r.cpp
@@ -11,7 +11,7 @@
 */
 
 #include <list>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/foreach.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -46,16 +46,16 @@ std::list<int> const &my_const_list = my_list;
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     boost::mpl::false_ *p = BOOST_FOREACH_IS_LIGHTWEIGHT_PROXY(my_list);
     (void)p;
 
     // non-const containers by value
-    BOOST_CHECK(sequence_equal_byval_n_r(my_list, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byval_n_r(my_list, "\5\4\3\2\1"));
 
     // const containers by value
-    BOOST_CHECK(sequence_equal_byval_c_r(my_const_list, "\5\4\3\2\1"));
+    BOOST_TEST(sequence_equal_byval_c_r(my_const_list, "\5\4\3\2\1"));
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/user_defined.cpp
+++ b/test/user_defined.cpp
@@ -8,7 +8,7 @@ Revision history:
 25 August 2005 : Initial version.
 */
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // define a user-defined collection type and teach BOOST_FOREACH how to enumerate it
@@ -41,7 +41,7 @@ namespace boost
 ///////////////////////////////////////////////////////////////////////////////
 // test_main
 //   
-int test_main( int, char*[] )
+int main()
 {
     // loop over a user-defined type (just make sure this compiles)
     mine::dummy d;
@@ -50,5 +50,5 @@ int test_main( int, char*[] )
         ((void)c); // no-op
     }
 
-    return 0;
+    return boost::report_errors();
 }


### PR DESCRIPTION
The test framework being used as been deprecated for years now. We're updating Boost libraries to use lightweight_test from Core instead.