### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,21 +5,24 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/iterator//boost_iterator
+    /boost/mpl//boost_mpl
+    /boost/range//boost_range
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/foreach
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/range//boost_range
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_foreach ]
+    [ alias boost_foreach : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_foreach test ]
     ;
 
 call-if : boost-library foreach
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,25 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/foreach
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/range//boost_range
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_foreach ]
+    [ alias all : boost_foreach test ]
+    ;
+
+call-if : boost-library foreach
+    ;

--- a/build.jam
+++ b/build.jam
@@ -14,12 +14,11 @@ constant boost_dependencies :
     /boost/type_traits//boost_type_traits ;
 
 project /boost/foreach
-    : common-requirements
-        <include>include
     ;
 
 explicit
-    [ alias boost_foreach : : : : <library>$(boost_dependencies) ]
+    [ alias boost_foreach : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_foreach test ]
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/foreach

--- a/build.jam
+++ b/build.jam
@@ -7,12 +7,12 @@ import project ;
 
 project /boost/foreach
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/range//boost_range
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/range//boost_range
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/foreach
     : common-requirements

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,7 +5,8 @@
 # bring in rules for testing
 import testing ;
 
-project : requirements <toolset>msvc:<asynch-exceptions>on ;
+project : requirements <toolset>msvc:<asynch-exceptions>on
+    <library>/boost/foreach//boost_foreach ;
 
 test-suite "foreach"
     : [ run stl_byval.cpp ]


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.